### PR TITLE
feat: add cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ docker compose up --build -d
       "password": "test"
     }
     ```
+- **Cache**
+  - Deal cards to all players - [http://localhost:5111/games/1/deal-cards](http://localhost:5111/games/1/deal-cards)
+  - If you want to deal new cards, you can ignore the cache by adding the `ignore_cache` query parameter. - [http://localhost:5111/games/1/deal-cards?ignore_cache=true](http://localhost:5111/games/1/deal-cards?ignore_cache=true)
 4. If you want to delete all containers, networks, volumes, images, run the following command in the root directory. If you want to remove the volumes as well, add the `--volumes` or `-v` flag.
 ```bash
 docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,10 @@ services:
       - "5111:5111"
     environment:
       - DATABASE_URL=postgresql://admin:qwerty@game-db:5432/db-games
+      - REDIS_URL=redis://redis:6379/0
     depends_on:
       - game-db
+      - redis
 
   game-db: 
     image: postgres:13
@@ -50,6 +52,11 @@ services:
     depends_on:
       - game
       - users
+  
+  redis:
+    image: redis:6-alpine
+    ports:
+      - "6379:6379"
 
 volumes:
   game-db-data:

--- a/services/game/db/db_init.sql
+++ b/services/game/db/db_init.sql
@@ -11,5 +11,6 @@ CREATE TABLE IF NOT EXISTS games (
     game_id SERIAL PRIMARY KEY,
     lobby_id INTEGER NOT NULL,
     winner_id INTEGER,
+    dealt_cards JSONB,
     FOREIGN KEY (lobby_id) REFERENCES lobbies(lobby_id)
 );

--- a/services/game/db/db_query.py
+++ b/services/game/db/db_query.py
@@ -191,7 +191,12 @@ def delete_lobby(lobby_id):
         conn.close()
         return jsonify({'error': 'Lobby not found'}), 404
 
+    # Delete the game associated with the lobby
+    cursor.execute('DELETE FROM games WHERE lobby_id = %s;', (lobby_id,))
+
+    # Delete the lobby
     cursor.execute('DELETE FROM lobbies WHERE lobby_id = %s;', (lobby_id,))
+    
     conn.commit()
     cursor.close()
     conn.close()
@@ -252,6 +257,9 @@ def deal_cards(game_id, deal_cards_all):
 
     # Deal cards
     result = deal_cards_all(num_players) 
+
+    # Store the dealt cards in the games table
+    cursor.execute('UPDATE games SET dealt_cards = %s WHERE game_id = %s;', (json.dumps(result), game_id))
 
     conn.commit()
     cursor.close()

--- a/services/game/requirements.txt
+++ b/services/game/requirements.txt
@@ -1,3 +1,4 @@
+async-timeout==4.0.3
 blinker==1.8.2
 certifi==2024.8.30
 charset-normalizer==3.3.2
@@ -8,6 +9,7 @@ itsdangerous==2.2.0
 Jinja2==3.1.4
 MarkupSafe==2.1.5
 psycopg2-binary==2.9.9
+redis==5.1.0
 requests==2.32.3
 urllib3==2.2.3
 Werkzeug==3.0.4

--- a/services/game/utils/poker.py
+++ b/services/game/utils/poker.py
@@ -70,7 +70,8 @@ def print_deck(deck=STANDARD_DECK, print_by_suit=False):
       print()
 
 # Function to deal cards to all players
-def deal_cards_all(num_players, deck=STANDARD_DECK):
+def deal_cards_all(num_players):
+    deck = generate_deck()
     shuffled_deck = shuffle_deck(deck)
     players = {f"player_{i+1}": [shuffled_deck.pop(), shuffled_deck.pop()] for i in range(num_players)}
     flop = [shuffled_deck.pop() for _ in range(3)]
@@ -154,7 +155,7 @@ if __name__ == "__main__":
     deck = generate_deck()
 
     print("\nDealing cards...")
-    # game = deal_cards_all(6, deck)
+    # game = deal_cards_all(6)
 
     game = {
       "flop": [


### PR DESCRIPTION
## Description
Add cache using `Redis` 

## Changes
### General
- Update `games` to store current dealt cards
- Update `docker-compose` for running the `Redis`  in `Docker`
- Cache dealt cards to avoid querying the database
- Add query parameter `ignore_cache=true` to deal a new set of cards
- Update delete lobby, as now it deletes the associated game 

### Docs
- Update `README` with cache info